### PR TITLE
Add `-a` flag for macOS

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 
 {% set github_version="0.2.0-m9" %}
 {% set version="0.2.0.m9" %}
-{% set build_number="1" %}
+{% set build_number="2" %}
 
 package:
   name: qupath

--- a/recipe/qupath-macos
+++ b/recipe/qupath-macos
@@ -10,5 +10,5 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 # Do run QuPath
-open -n "${DIR}/QuPath.app" --args "$@"
+open -n "${DIR}/QuPath.app" --args "$@" || open -a "${DIR}/QuPath.app" --args "$@"
 

--- a/recipe/qupath-macos
+++ b/recipe/qupath-macos
@@ -10,5 +10,5 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 # Do run QuPath
-open -n "${DIR}/QuPath.app" --args "$@" || open -a "${DIR}/QuPath.app" --args "$@"
+open -n -a "${DIR}/QuPath.app" --args "$@"
 


### PR DESCRIPTION
I've been having trouble running this from my Mac, and I figured out that I needed to use the `-a` flag to open QuPath for the first time. After that, it can run with just the `-n` flag.

This pull request adds the `-a` flag to the opening command, which should work every time.

Here is what I experienced:
```
qupath
No application knows how to open file:///opt/anaconda3/envs/qupath/bin/QuPath.app/ (Error Domain=NSOSStatusErrorDomain Code=-10814 "kLSApplicationNotFoundErr: E.g. no application claims the file" UserInfo={_LSLine=1479, _LSFunction=runEvaluator}).
# this returns an error initially

~ open -a /opt/anaconda3/envs/qupath/bin/QuPath.app
# this works

~ qupath
# now this works
```